### PR TITLE
Fix indexed bucket stored bytes

### DIFF
--- a/packages/api/src/IndexerApi/IndexerApi.ts
+++ b/packages/api/src/IndexerApi/IndexerApi.ts
@@ -30,6 +30,7 @@ type DdcNodesResult = {
 const mapBucket = (bucket: IndexedBucket): IndexedBucket => ({
   ...bucket,
   id: BigInt(bucket.id),
+  storedBytes: 0, // TODO: get storedBytes from `usage`.
 });
 
 const mapResultToAccount = ({ data: { account } }: AccountResult): IndexedAccount =>


### PR DESCRIPTION
The current version tries to query `bucket.storedBytes` from the blockchain indexer which never set it and always returned `0` because there was no DAC validation which is expected to set it on chain first. An updated version of the blockchain indexer removes `bucket.storedBytes` in favor of `bucket.usage` with a time series of historical changes of the bucket usage values. It makes the existing query fail.

This patch fixes query failure returning it to work the same as we had with the previous version of the indexer API. 